### PR TITLE
Use TLSv1 not SSLv3 after Poodle vuln

### DIFF
--- a/lib/hover.rb
+++ b/lib/hover.rb
@@ -2,7 +2,7 @@ require "hover/version"
 require "hover/api"
 
 # rest-client doesn't allow use to ssl_version (as of 1.6.7)
-OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = 'SSLv3'
+OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:ssl_version] = 'TLSv1'
 
 module Hover
   # Your code goes here...


### PR DESCRIPTION
I think Hover stopped supporting SSLv3 after the Poodle vulnerability. Change default protocol from SSLv3 to TLSv1. 
